### PR TITLE
Move #most_recent_transition_join to be a public method

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -20,7 +20,7 @@ module Statesman
             where("NOT (#{states_where(most_recent_transition_alias, states)})",
                   states)
         end
-        
+
         def most_recent_transition_join
           "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
              ON #{table_name}.id =

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -20,6 +20,13 @@ module Statesman
             where("NOT (#{states_where(most_recent_transition_alias, states)})",
                   states)
         end
+        
+        def most_recent_transition_join
+          "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
+             ON #{table_name}.id =
+                  #{most_recent_transition_alias}.#{model_foreign_key}
+             AND #{most_recent_transition_alias}.most_recent = #{db_true}"
+        end
 
         private
 
@@ -53,13 +60,6 @@ module Statesman
 
         def model_table
           transition_reflection.table_name
-        end
-
-        def most_recent_transition_join
-          "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
-             ON #{table_name}.id =
-                  #{most_recent_transition_alias}.#{model_foreign_key}
-             AND #{most_recent_transition_alias}.most_recent = #{db_true}"
         end
 
         def states_where(temporary_table_name, states)


### PR DESCRIPTION
ActiveRecord's `#or` method requires that both sides of the query must have a compatible structure as such:

```ruby
User.joins(:profile).where(name: "John").or(User.where(name: "Tom")).count
# => ArgumentError: Relation passed to #or must be structurally compatible. Incompatible values: [:joins]

User.joins(:profile).where(name: "John").or(User.joins(:profile).where(name: "Tom")).count
# => 2
```

The `#in_state` and `#not_in_state` methods of statesman chain the `#joins` and the `#where` calls together. This makes a query with ActiveRecord `#or`.

For example the following would produce an error since the query does not also include the `#joins`

```ruby
class Store < ActiveRecord::Base
  # ...
  scope :belongs_to_user, -> (user) { where(user: user) }
  # ...
end

Post.in_state(:published).or(Post.belongs_to_user(current_user))
```

With this change the `#most_recent_transition_join` method is exposed meaning that the following query could be possible resolving the issue:

```ruby
Post
  .in_state(:published)
  .or(Post.most_recent_transition_join.belongs_to_user(current_user))
```

Further instances and resources relating to this issue can be found at:

https://github.com/varvet/pundit/issues/440#issuecomment-277204775

http://codeatmorning.com/rails-5-meet-the-active-record-or-query/